### PR TITLE
Fix argument name for dotacion estimation

### DIFF
--- a/train_models.py
+++ b/train_models.py
@@ -245,9 +245,12 @@ def generate_predictions(
     # cálculo de dotación óptima (igual que antes) …
     dots, effs = [], []
     for _, r in df_out.iterrows():
+        # `estimar_dotacion_optima` espera el parámetro opcional
+        # `params_efectividad`. El nombre `params_sig` aquí provocaba
+        # un error de tipo por argumento inesperado.
         dot, eff = estimar_dotacion_optima(
             [r["T_AO_pred"]], [r["T_AO_VENTA_req"]],
-            efectividad_obj, params_sig=None
+            efectividad_obj
         )
         dots.append(dot); effs.append(eff)
 


### PR DESCRIPTION
## Summary
- remove incorrect `params_sig` keyword when calling `estimar_dotacion_optima`
- add clarifying comment about expected parameter

## Testing
- `python -m py_compile train_models.py`
- `python -m py_compile utils.py preprocessing.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_687f1fb0fa7883288e75b898c1fc3c3c