### PR TITLE
Enable predictions for Aug-Nov 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ python train_models.py
 
 Los modelos resultantes se guardarán en la carpeta `models_lgbm/`.
 
+### Predicciones para agosto–noviembre 2025
+
+El script `train_models.py` ahora permite especificar un rango de fechas
+para la generación de pronósticos. Por defecto, al ejecutarlo se
+entrenan los modelos y se produce un ejemplo de predicción para el
+periodo del **2 de agosto de 2025 al 2 de noviembre de 2025**.
+
 ## Ejecución de la aplicación
 
 Para lanzar la aplicación en modo local:


### PR DESCRIPTION
## Summary
- add previous-year monthly features in `prepare_features`
- allow specifying start and end date for predictions
- example run now predicts 2 Aug 2025 through 2 Nov 2025
- document new prediction period in README

## Testing
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*
- `python train_models.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687ff92d87e4832898312c6e6f0157f6