### PR TITLE
Update prediction horizon to end of 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ python train_models.py
 
 Los modelos resultantes se guardarán en la carpeta `models_lgbm/`.
 
-### Predicciones para agosto–noviembre 2025
+### Predicciones hasta fin de 2025
 
-El script `train_models.py` ahora permite especificar un rango de fechas
-para la generación de pronósticos. Por defecto, al ejecutarlo se
-entrenan los modelos y se produce un ejemplo de predicción para el
-periodo del **2 de agosto de 2025 al 2 de noviembre de 2025**.
+El script `train_models.py` permite especificar un rango de fechas para la
+generación de pronósticos. Por defecto, al ejecutarlo se entrenan los modelos y
+se produce un ejemplo de predicción que cubre desde el día siguiente al último
+registro disponible hasta el **31 de diciembre de 2025**.
 
 ## Ejecución de la aplicación
 


### PR DESCRIPTION
## Summary
- adjust README to mention forecasts to end of 2025
- compute prediction horizon dynamically in app and training script
- use slider value when forecasting

## Testing
- `python -m py_compile app.py train_models.py preprocessing.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68800b09eec88328a838a6d206b14311