### PR TITLE
Switch training to SARIMA forecasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Este proyecto contiene un conjunto de scripts y una aplicación web para predecir
 la dotación y otras métricas operacionales de distintas sucursales. La interfaz
-web está implementada con **Streamlit** y utiliza modelos entrenados con
-**LightGBM**.
+web está implementada con **Streamlit** y utiliza modelos de series de tiempo
+entrenados con **SARIMA**.
 
 ## Contenido del repositorio
 
@@ -11,7 +11,7 @@ web está implementada con **Streamlit** y utiliza modelos entrenados con
 - `train_models.py` – Script de entrenamiento de modelos por sucursal.
 - `preprocessing.py` y `utils.py` – Funciones auxiliares para
   procesamiento y modelamiento.
-- `models_lgbm/` – Modelos ya entrenados en formato `pkl`.
+- `models_sarima/` – Modelos ya entrenados en formato `pkl`.
 - `data/` – Archivos de datos de ejemplo (`DOTACION_EFECTIVIDAD.xlsx`,
   `regions.xlsx`, etc.).
 
@@ -32,7 +32,7 @@ Si deseas generar nuevamente los modelos, ejecuta:
 python train_models.py
 ```
 
-Los modelos resultantes se guardarán en la carpeta `models_lgbm/`.
+Los modelos resultantes se guardarán en la carpeta `models_sarima/`.
 
 ### Predicciones hasta fin de 2025
 

--- a/train_models.py
+++ b/train_models.py
@@ -3,11 +3,11 @@ from datetime import timedelta
 import joblib
 import pandas as pd
 import numpy as np
-from sklearn.linear_model import LinearRegression
+from statsmodels.tsa.statespace.sarimax import SARIMAX
 
-from preprocessing import basic_preprocess, prepare_features
 
-MODEL_DIR = "models_simple"
+
+MODEL_DIR = "models_sarima"
 TARGETS = ["T_VISITAS", "T_AO"]
 HOURS_RANGE = list(range(9, 22))
 
@@ -18,18 +18,47 @@ def load_data(path: str = "data/DOTACION_EFECTIVIDAD.xlsx") -> pd.DataFrame:
 
 
 def train_models(df: pd.DataFrame) -> None:
-    """Train a simple linear model for each target."""
+    """Train a SARIMA model for each branch and target."""
     os.makedirs(MODEL_DIR, exist_ok=True)
-    df_proc = basic_preprocess(df)
-    for target in TARGETS:
-        X, y = prepare_features(df_proc, target)
-        model = LinearRegression()
-        model.fit(X, y)
-        joblib.dump(model, os.path.join(MODEL_DIR, f"predictor_{target}.pkl"))
+
+    df = df.copy()
+    df.columns = df.columns.str.strip().str.upper()
+    df["FECHA"] = pd.to_datetime(df["FECHA"])
+    df["COD_SUC"] = df["COD_SUC"].astype(str).str.strip()
+
+    # Aggregate at daily level
+    df_daily = (
+        df.groupby(["COD_SUC", "FECHA"])[TARGETS]
+        .sum()
+        .sort_index()
+        .reset_index()
+    )
+
+    for branch in df_daily["COD_SUC"].unique():
+        df_branch = (
+            df_daily[df_daily["COD_SUC"] == branch]
+            .set_index("FECHA")
+            .asfreq("D")
+            .fillna(0)
+        )
+
+        for target in TARGETS:
+            series = df_branch[target]
+            model = SARIMAX(
+                series,
+                order=(1, 1, 1),
+                seasonal_order=(1, 1, 1, 7),
+                enforce_stationarity=False,
+                enforce_invertibility=False,
+            ).fit(disp=False)
+
+            fname = f"sarima_{target}_{branch}.pkl"
+            joblib.dump(model, os.path.join(MODEL_DIR, fname))
 
 
-def _load_model(target: str) -> LinearRegression:
-    path = os.path.join(MODEL_DIR, f"predictor_{target}.pkl")
+def _load_model(target: str, branch: str):
+    fname = f"sarima_{target}_{branch}.pkl"
+    path = os.path.join(MODEL_DIR, fname)
     return joblib.load(path)
 
 
@@ -38,24 +67,33 @@ def generate_predictions(
     branch: str,
     days: int = 7,
     efectividad_obj: float = 0.6,
+    start_date: pd.Timestamp | None = None,
+    end_date: pd.Timestamp | None = None,
 ) -> pd.DataFrame:
-    """Generate naive hourly predictions for the next ``days`` days."""
-    models = {t: _load_model(t) for t in TARGETS}
-    last_date = df_hist[df_hist["COD_SUC"] == branch]["FECHA"].max()
-    start_dt = pd.to_datetime(last_date) + timedelta(days=1)
+    """Generate hourly predictions for the next ``days`` days using SARIMA."""
 
-    future_rows = []
-    for d in range(days):
-        fecha = start_dt + timedelta(days=d)
+    models = {t: _load_model(t, branch) for t in TARGETS}
+
+    if start_date is None:
+        last_date = df_hist[df_hist["COD_SUC"] == branch]["FECHA"].max()
+        start_date = pd.to_datetime(last_date) + timedelta(days=1)
+
+    if end_date is None:
+        end_date = start_date + timedelta(days=days - 1)
+
+    horizon = (end_date - start_date).days + 1
+    pred_index = pd.date_range(start_date, periods=horizon, freq="D")
+
+    result_rows = []
+    for fecha in pred_index:
         for h in HOURS_RANGE:
-            future_rows.append({"COD_SUC": branch, "FECHA": fecha, "HORA": h})
-    df_future = pd.DataFrame(future_rows)
-    df_proc = basic_preprocess(df_future)
+            result_rows.append({"COD_SUC": branch, "FECHA": fecha, "HORA": h})
+    result = pd.DataFrame(result_rows)
 
-    result = df_future.copy()
-    for t in TARGETS:
-        X, _ = prepare_features(df_proc, t)
-        result[f"{t}_pred"] = models[t].predict(X).clip(min=0)
+    for t, model in models.items():
+        forecast = model.get_forecast(steps=horizon)
+        preds = forecast.predicted_mean.clip(lower=0)
+        result[f"{t}_pred"] = np.repeat(preds.values, len(HOURS_RANGE))
 
     result["T_AO_VENTA_req"] = result["T_AO_pred"] * efectividad_obj
     result["P_EFECTIVIDAD_req"] = np.where(


### PR DESCRIPTION
## Summary
- use SARIMA models for time series training
- store models in `models_sarima/`
- support hourly forecasts from SARIMA daily predictions
- update README to reflect SARIMA usage

## Testing
- `python -m py_compile train_models.py`
- `python -m py_compile app.py`
- `pip install pandas openpyxl` *(fails: Could not connect)*

------
https://chatgpt.com/codex/tasks/task_e_6880da8628a48328b5bcaa6e875b0cf7