### PR TITLE
Fix SARIMAX training error with boolean exogenous data

### DIFF
--- a/train_models.py
+++ b/train_models.py
@@ -48,6 +48,7 @@ def train_models(df: pd.DataFrame) -> None:
         )
 
         exog = pd.get_dummies(df_branch.index.weekday, drop_first=False)
+        exog = exog.astype(float)  # Ensure numeric dtype to avoid bool diff issue
         # Ensure exogenous variables use the same index as the target series
         exog.index = df_branch.index
 


### PR DESCRIPTION
## Summary
- ensure weekday dummies passed to SARIMAX are float

## Testing
- `python train_models.py` *(fails: ModuleNotFoundError: No module named 'joblib')*
- `pip install joblib` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6880e93e874083288328273d9efeae1a