### PR TITLE
Improve realism of predictions with optional noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ La aplicación utiliza un método vectorizado que acelera la inferencia para
 horizontes extensos y las proyecciones para el periodo abril–diciembre de 2025
 se basan en los promedios históricos de 2024.
 
+El módulo `generate_predictions` ahora permite añadir ruido gaussiano opcional
+(parámetro `noise_scale`) para simular la volatilidad observada en la data real.
+
 ## Ejecución de la aplicación
 
 Para lanzar la aplicación en modo local:


### PR DESCRIPTION
## Summary
- add a `noise_scale` parameter to `generate_predictions` to optionally add Gaussian noise
- document new option in README

## Testing
- `python -m py_compile train_models.py preprocessing.py utils.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_6880ef3e2468832883dfe3273baf5fd8