### PR TITLE
Add Prophet forecasts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ scipy
 holidays
 workalendar
 openpyxl
+prophet


### PR DESCRIPTION
## Summary
- implement `forecast_dotacion_prophet` with Prophet modeling
- train models and save Prophet forecasts using CLI arguments for noise and changepoint prior scale
- add optional Prophet display in Streamlit app
- include Prophet package in requirements

## Testing
- `python -m py_compile preprocessing.py train_models.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_6880f45298a88328989bd76a1b569910