### PR TITLE
Add argparse options to Prophet forecast script

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ python train_models.py
 Los modelos resultantes se guardarán en la carpeta `models_sarima/`.
 
 
-Para generar pronosticos con Prophet de *T_VISITAS* y *T_AO* ejecuta:
+Para generar pronósticos con Prophet de *T_VISITAS* y *T_AO* ejecuta:
 ```bash
-python prophet_forecast_targets.py
+python prophet_forecast_targets.py --horizon_days 90 --changepoint_prior_scale 0.3
 ```
 Los resultados se guardarán en `models_prophet/`.
 

--- a/prophet_forecast_targets.py
+++ b/prophet_forecast_targets.py
@@ -1,4 +1,5 @@
 import os
+import argparse
 import pandas as pd
 from prophet import Prophet
 
@@ -42,4 +43,23 @@ def main(horizon_days: int = 365, changepoint_prior_scale: float = 0.5) -> None:
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(
+        description="Generate Prophet forecasts for T_VISITAS and T_AO"
+    )
+    parser.add_argument(
+        "--horizon_days",
+        type=int,
+        default=365,
+        help="Number of days to forecast",
+    )
+    parser.add_argument(
+        "--changepoint_prior_scale",
+        type=float,
+        default=0.5,
+        help="Prophet changepoint prior scale",
+    )
+    args = parser.parse_args()
+    main(
+        horizon_days=args.horizon_days,
+        changepoint_prior_scale=args.changepoint_prior_scale,
+    )


### PR DESCRIPTION
## Summary
- parse `--horizon_days` and `--changepoint_prior_scale` in `prophet_forecast_targets.py`
- document new arguments in README

## Testing
- `python prophet_forecast_targets.py --horizon_days 1 --help` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement streamlit)*

------
https://chatgpt.com/codex/tasks/task_e_68814354238c8328b4888eee1fc62d56