### PR TITLE
Update deploy script to reuse models

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ python train_models.py
 
 Los modelos resultantes se guardarán en la carpeta `models_prophet/`.
 
+`deploy_prophet.py` utiliza esos modelos guardados para generar los pronósticos.
+Solo necesitas ejecutarlo después de entrenar para obtener los CSV y gráficos.
+
 
 Para generar pronósticos con Prophet de *T_VISITAS* y *T_AO* y guardar una
 gráfica por variable ejecuta:


### PR DESCRIPTION
## Summary
- load previously trained Prophet models in `deploy_prophet.py`
- clarify in README that deployment uses the saved models

## Testing
- `python -m py_compile deploy_prophet.py train_models.py preprocessing.py utils.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_688178c9d5b48328b36a821820e31451