### PR TITLE
Ajusta k de forma automática y simplifica curva

### DIFF
--- a/app.py
+++ b/app.py
@@ -339,15 +339,9 @@ k_def   = params_eff['k']
 x0_base = params_eff['x0_base']
 x0_fac  = params_eff['x0_factor_t_ao_venta']
 
-# 2. Parámetro k personalizable, inicializado con el valor por defecto de la sucursal
-k = st.number_input(
-    "Coeficiente k = Pendiente de la Curva (T_AO)",
-    min_value=0.0, max_value=2.0,
-    value=float(k_def),
-    step=0.01,
-    format="%.2f",
-    key=f"k_{cod_suc}"
-)
+# 2. Coeficiente k estimado para la sucursal
+k = float(k_def)
+st.write(f"Coeficiente k estimado: {k:.2f}")
 
 # 3. Rango de dotación fijo entre 0 y 12 (enteros)
 dot_range = np.arange(0, 13)
@@ -395,14 +389,6 @@ fig.update_layout(
     plot_bgcolor="#1a0033",
     font_color="#FFFFFF",
     title_font_color="#FFFFFF"
-)
-fig.add_vline(
-    x=dot_opt,
-    line_dash="dash",
-    line_color="yellow",
-    annotation_text=f"X óptimo: {dot_opt}",
-    annotation_position="top left",
-    annotation_font_color="yellow",
 )
 fig.add_trace(
     go.Scatter(


### PR DESCRIPTION
## Summary
- estima el coeficiente `k` para cada sucursal usando su historial
- muestra el valor estimado en la interfaz y elimina el input manual
- remueve la línea vertical amarilla en la curva de efectividad

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6881876545d88328b6e2ab4f2df05de8