### PR TITLE
Improve table and dropdown styling

### DIFF
--- a/app.py
+++ b/app.py
@@ -98,6 +98,32 @@ st.markdown(
     div[data-baseweb="slider"] span {{
       background-color: var(--accent) !important;
     }}
+    /* Tablas incrustadas en el fondo */
+    .stDataFrame, .stTable {
+      background-color: var(--dark-bg) !important;
+      border: none;
+    }
+    .stTable table {
+      background-color: var(--dark-bg) !important;
+      color: var(--white);
+    }
+    .stTable th {
+      background-color: var(--primary) !important;
+      color: var(--white);
+    }
+    /* Dropdown integrado */
+    .stSelectbox div[data-baseweb="select"] > div {
+      background-color: var(--dark-bg);
+      color: var(--white);
+      border-color: var(--primary);
+    }
+    .stSelectbox div[data-baseweb="select"] > div:hover {
+      border-color: var(--accent);
+    }
+    .stSelectbox div[data-baseweb="select"] > div:focus-within {
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(241,172,75,0.4);
+    }
     </style>
     """,
     unsafe_allow_html=True


### PR DESCRIPTION
## Summary
- adjust DataFrame and table colors to use the same dark background
- style dropdowns so they blend with the theme

## Testing
- `python -m py_compile app.py preprocessing.py train_models.py deploy_prophet.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68819bc869e48328b8c54e5bd64e562c