### PR TITLE
Unify table background styling

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,7 +17,9 @@ from plotly.subplots import make_subplots
 # https://brand.ripley.cl
 PRIMARY_COLOR   = "#4F2D7F"  # Minsk
 DARK_BG_COLOR   = "#361860"  # Scarlet Gum
-TABLE_BG_COLOR  = DARK_BG_COLOR
+# Color de fondo para secciones claras y tablas
+PRIMARY_BG      = "#F8F9FA"
+TABLE_BG_COLOR  = PRIMARY_BG
 ACCENT_COLOR    = "#F1AC4B"  # Sandy Brown
 WHITE           = "#FFFFFF"
 BLACK           = "#000000"
@@ -52,7 +54,7 @@ st.markdown(
     /* DataFrame: fondo de la tabla y de las celdas */
     .stDataFrame div[role="table"] {{
       background-color: var(--table-bg) !important;
-      color: var(--white);
+      color: var(--black);
     }}
     /* Para los encabezados de tabla */
     .stDataFrame th {{
@@ -111,7 +113,7 @@ st.markdown(
     }}
     div[data-testid="stDataFrame"] table {{
       background-color: var(--table-bg) !important;
-      color: var(--white) !important;
+      color: var(--black) !important;
     }}
     div[data-testid="stDataFrame"] th {{
       background-color: var(--primary) !important;
@@ -119,7 +121,7 @@ st.markdown(
     }}
     .stTable table {{
       background-color: var(--table-bg) !important;
-      color: var(--white);
+      color: var(--black);
     }}
     .stTable th {{
       background-color: var(--primary) !important;


### PR DESCRIPTION
## Summary
- set all tables to use the shared background color
- adjust CSS to render text in black on light tables

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6881a624df60832892c248d4f0f5fdc0