### PR TITLE
Add login via streamlit-authenticator

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ from train_models import generate_predictions
 import plotly.express as px
 from preprocessing import assign_turno, prepare_features
 from utils import calcular_efectividad, estimar_dotacion_optima, estimar_parametros_efectividad
+import streamlit_authenticator as stauth
 import pydeck as pdk
 import plotly.graph_objects as go
 
@@ -164,6 +165,33 @@ with col2:
         "https://upload.wikimedia.org/wikipedia/commons/2/27/Logo_Ripley_banco_2.png",
         width=750
     )
+
+
+# --- AUTENTICACIÓN ---
+names = ["Administrador"]
+usernames = ["admin"]
+passwords = ["admin123"]
+hashed_passwords = stauth.Hasher(passwords).generate()
+
+authenticator = stauth.Authenticate(
+    names,
+    usernames,
+    hashed_passwords,
+    "auth_cookie",
+    "some_signature_key",
+    cookie_expiry_days=1,
+)
+
+name, authentication_status, username = authenticator.login("Login", "main")
+if authentication_status:
+    authenticator.logout("Logout", "sidebar")
+    st.sidebar.success(f"Bienvenido {name}")
+elif authentication_status is False:
+    st.error("Usuario o contraseña incorrectos")
+    st.stop()
+else:
+    st.warning("Por favor, ingresa tus credenciales")
+    st.stop()
 
 
 # --- CARGA DE DATOS ---

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ holidays
 workalendar
 openpyxl
 prophet
+streamlit-authenticator


### PR DESCRIPTION
## Summary
- add streamlit-authenticator requirement
- integrate login screen into app using streamlit-authenticator

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6882f3708fd48328b985fff172f6e752