### PR TITLE
Add range slider to dotación vs efectividad chart

### DIFF
--- a/app.py
+++ b/app.py
@@ -525,7 +525,7 @@ with tab_pred:
     # rango deslizante similar al utilizado en la gráfica de ventas
     fig.update_xaxes(
         range=[dot_range.min(), dot_range.max()],
-        rangeslider_visible=False,
+        rangeslider_visible=True,
     )
     st.plotly_chart(fig, use_container_width=True)
 


### PR DESCRIPTION
## Summary
- expose the range slider on the Dotación vs Efectividad plot

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6883fa36dc508328b9f52696428b6cf8