### PR TITLE
Fix header color for consistent display

### DIFF
--- a/app.py
+++ b/app.py
@@ -67,6 +67,10 @@ st.markdown(
       --white: {WHITE};
       --black: {BLACK};
     }}
+    /* Aseguramos mismo color de los encabezados en todas las plataformas */
+    h1, h2, h3, h4, h5, h6 {{
+      color: var(--white);
+    }}
     /* Fondo general */
     .stApp, .css-1d391kg {{
       background-color: var(--dark-bg);


### PR DESCRIPTION
## Summary
- ensure header titles always use `var(--white)` color so they look consistent across desktop and mobile web

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688422a07a388328ac50f95e3801e5b5