### PR TITLE
Fix CSS braces in app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -152,10 +152,10 @@ st.markdown(
       color: var(--white);
     }}
     /* Imágenes responsivas */
-    img {
+    img {{
       max-width: 100%;
       height: auto;
-    }
+    }}
     /* Dropdown integrado */
     .stSelectbox div[data-baseweb="select"] > div {{
       background-color: var(--dark-bg);


### PR DESCRIPTION
## Summary
- escape braces for the `img` CSS rule to avoid NameError when rendering the page

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6884237837208328875ed50b379e31bd