### PR TITLE
Fix pivot order for missing days

### DIFF
--- a/app.py
+++ b/app.py
@@ -1008,7 +1008,7 @@ with tab_turno:
     pivot_conv = (
         conv_dt
         .pivot(index='DiaSemana', columns='Turno', values='Conversion')
-        .loc[dias, list(turnos.values())]
+        .reindex(index=dias, columns=list(turnos.values()))
     )
 
     # 4) Convertir a % para mostrar


### PR DESCRIPTION
## Summary
- avoid KeyError when a day is missing for certain branches

## Testing
- `python -m py_compile app.py preprocessing.py train_models.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68865ec74e988328ab87fefb32b146b7