### PR TITLE
Update noise slider and alt scenario color

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,7 +29,7 @@ PRIMARY_RGBA = "[79, 45, 127, 255]"  # Minsk en formato RGBA para resaltar
 COLOR_DISCRETE_MAP = {
     "Histórico": ACCENT_COLOR,
     "Escenario base": PRIMARY_BG,
-    "Escenario alterno": "#00CC96",
+    "Escenario alterno": "#FF4B4B",  # rojo para diferenciar el escenario alterno
 }
 # Colores para series donde se muestran dos categorías
 # (e.g. Semana vs Fin de Semana) en gráficas de torta o barras
@@ -408,7 +408,7 @@ with tab_pred:
         label="",
         min_value=0.0,
         max_value=2.0,
-        value=0.5,
+        value=2.0,
         step=0.1,
         format="%.1f",
         label_visibility="collapsed",


### PR DESCRIPTION
## Summary
- set default noise slider value to 2.0
- color alternate scenario series in red

## Testing
- `python -m py_compile app.py deploy_prophet.py preprocessing.py train_models.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6886f16815dc832889dd94771a70e8c0