### PR TITLE
Add red downward arrow to worst branch metric

### DIFF
--- a/app.py
+++ b/app.py
@@ -385,7 +385,14 @@ with tab_mapa:
     worst_val = eff_branch.loc[worst_id, 'ef']
     best_val = eff_branch.loc[best_id, 'ef']
     cols_eff = st.columns(2)
-    cols_eff[0].metric("Peor efectividad", f"Sucursal {worst_id}", f"{worst_val:.1%}")
+    delta_worst = worst_val - best_val
+    cols_eff[0].metric(
+        "Peor efectividad",
+        f"Sucursal {worst_id}",
+        f"{worst_val:.1%}",
+        delta=f"{delta_worst:.1%}",
+        delta_color="normal",
+    )
     cols_eff[1].metric("Mejor efectividad", f"Sucursal {best_id}", f"{best_val:.1%}")
 
     st.markdown("---")


### PR DESCRIPTION
## Summary
- show a downward arrow for the branch with worst effectiveness

## Testing
- `python -m py_compile app.py preprocessing.py train_models.py deploy_prophet.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6887145eb6bc832881565f4d112079e6