### PR TITLE
Add DOTACION forecasting and display

### DIFF
--- a/app.py
+++ b/app.py
@@ -601,8 +601,11 @@ with tab_pred:
         "HORA",
         "T_VISITAS_pred",
         "T_AO_pred",
+        "DOTACION_pred",
         "T_AO_VENTA_req",
-        "P_EFECTIVIDAD_req"
+        "P_EFECTIVIDAD_req",
+        "DOTACION_req",
+        "DOTACION_gap",
     ]].copy()
 
     # 2) Formateamos FECHA y añadimos día de la semana
@@ -614,8 +617,11 @@ with tab_pred:
         "HORA": "Hora",
         "T_VISITAS_pred": "Visitas estimadas",
         "T_AO_pred": "Ofertas aceptadas estimadas",
+        "DOTACION_pred": "Dotación estimada",
         "T_AO_VENTA_req": "Ventas requeridas",
         "P_EFECTIVIDAD_req": "% Efectividad requerida",
+        "DOTACION_req": "Dotación requerida",
+        "DOTACION_gap": "Gap dotación",
     })
 
     # 4) Redondeamos y transformamos tipos
@@ -623,17 +629,28 @@ with tab_pred:
     df_hourly["Ofertas aceptadas estimadas"] = df_hourly["Ofertas aceptadas estimadas"].round(0).astype(int)
     df_hourly["Ventas requeridas"] = df_hourly["Ventas requeridas"].round(0).astype(int)
     df_hourly["% Efectividad requerida"] = df_hourly["% Efectividad requerida"].round(2)
+    df_hourly["Dotación estimada"] = df_hourly["Dotación estimada"].round(0).astype(int)
+    df_hourly["Dotación requerida"] = df_hourly["Dotación requerida"].round(0).astype(int)
+    df_hourly["Gap dotación"] = df_hourly["Gap dotación"].round(1)
 
     # Preparamos una copia solo para mostrar, aplicando formato de miles
     df_hourly_display = df_hourly.copy()
-    for col in ["Visitas estimadas", "Ofertas aceptadas estimadas", "Ventas requeridas"]:
+    for col in [
+        "Visitas estimadas",
+        "Ofertas aceptadas estimadas",
+        "Ventas requeridas",
+        "Dotación estimada",
+        "Dotación requerida",
+        "Gap dotación",
+    ]:
         df_hourly_display[col] = df_hourly_display[col].apply(lambda x: f"{x:,}".replace(',', '.'))
 
     # 5) Seleccionamos el orden final de columnas
     df_hourly = df_hourly[[
         "Fecha registro", "Día", "Hora",
         "Visitas estimadas", "Ofertas aceptadas estimadas",
-        "Ventas requeridas", "% Efectividad requerida"
+        "Ventas requeridas", "% Efectividad requerida",
+        "Dotación estimada", "Dotación requerida", "Gap dotación"
     ]]
     df_hourly_display = df_hourly_display[df_hourly.columns]
 
@@ -649,12 +666,18 @@ with tab_pred:
             "Visitas estimadas": "sum",
             "Ofertas aceptadas estimadas": "sum",
             "Ventas requeridas": "sum",
-            "% Efectividad requerida": "mean"
+            "% Efectividad requerida": "mean",
+            "Dotación estimada": "mean",
+            "Dotación requerida": "mean",
+            "Gap dotación": "mean",
         })
     )
 
     # Redondeo final de efectividad
     df_daily["% Efectividad requerida"] = df_daily["% Efectividad requerida"].round(2)
+    df_daily["Dotación estimada"] = df_daily["Dotación estimada"].round(1)
+    df_daily["Dotación requerida"] = df_daily["Dotación requerida"].round(1)
+    df_daily["Gap dotación"] = df_daily["Gap dotación"].round(1)
 
     # Orden cronológico
     df_daily["_dt"] = pd.to_datetime(df_daily["Fecha registro"], format="%d-%m-%Y")
@@ -662,8 +685,28 @@ with tab_pred:
 
     # Preparamos una copia formateada solo para mostrar
     df_daily_display = df_daily.copy()
-    for col in ["Visitas estimadas", "Ofertas aceptadas estimadas", "Ventas requeridas"]:
-        df_daily_display[col] = df_daily_display[col].apply(lambda x: f"{int(x):,}".replace(',', '.'))
+    for col in [
+        "Visitas estimadas",
+        "Ofertas aceptadas estimadas",
+        "Ventas requeridas",
+        "Dotación estimada",
+        "Dotación requerida",
+        "Gap dotación",
+    ]:
+        df_daily_display[col] = df_daily_display[col].apply(lambda x: f"{round(x,1):,}".replace(',', '.'))
+
+    df_daily = df_daily[[
+        "Fecha registro",
+        "Día",
+        "Visitas estimadas",
+        "Ofertas aceptadas estimadas",
+        "Ventas requeridas",
+        "% Efectividad requerida",
+        "Dotación estimada",
+        "Dotación requerida",
+        "Gap dotación",
+    ]]
+    df_daily_display = df_daily_display[df_daily.columns]
 
     st.dataframe(df_daily_display, use_container_width=True, hide_index=True)
 


### PR DESCRIPTION
## Summary
- include DOTACION as a prophet target
- generate hourly DOTACION predictions in `generate_predictions`
- show predicted/required staffing in hourly and daily tables

## Testing
- `python -m py_compile train_models.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_688bf3b84e6c8328a3fdd931bf299cef