### PR TITLE
Add interactive forecast table

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ workalendar
 openpyxl
 prophet
 streamlit-authenticator
+streamlit-aggrid


### PR DESCRIPTION
## Summary
- integrate `streamlit-aggrid` for better tables
- replace daily/hourly tables with a single grouped table in Forecast tab

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ced86c7ec83288b157bac5f36893a