### PR TITLE
Fix avg dotacion display format

### DIFF
--- a/app.py
+++ b/app.py
@@ -683,10 +683,24 @@ with tab_pred:
                        valueFormatter="params.value.toFixed(2)")
     gb.configure_column("Dotación requerida", type=["numericColumn"], aggFunc="avg",
                        valueFormatter="Math.round(params.value).toLocaleString('es-ES')")
-    gb.configure_column("Dotación histórica", type=["numericColumn"], aggFunc="avg",
-                       valueFormatter="Math.round(params.value).toLocaleString('es-ES')")
-    gb.configure_column("Ajuste dotación", type=["numericColumn"], aggFunc="avg",
-                       valueFormatter="Math.round(params.value).toLocaleString('es-ES')")
+    gb.configure_column(
+        "Dotación histórica",
+        type=["numericColumn"],
+        aggFunc="avg",
+        valueFormatter=(
+            "params.node.group ? Number(params.value).toFixed(2) : "
+            "Math.round(params.value).toLocaleString('es-ES')"
+        ),
+    )
+    gb.configure_column(
+        "Ajuste dotación",
+        type=["numericColumn"],
+        aggFunc="avg",
+        valueFormatter=(
+            "params.node.group ? Number(params.value).toFixed(2) : "
+            "Math.round(params.value).toLocaleString('es-ES')"
+        ),
+    )
     gb.configure_grid_options(groupDefaultExpanded=0)
     grid_options = gb.build()
 


### PR DESCRIPTION
## Summary
- tweak AgGrid column formatter for `Dotación histórica` and `Ajuste dotación`
- show decimal averages when grouping rows

## Testing
- `python -m py_compile app.py preprocessing.py train_models.py deploy_prophet.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_688d0f73b1c0832894fa310842bd204b