### PR TITLE
Unify chart background color

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,12 +17,12 @@ from plotly.subplots import make_subplots
 ACCENT_COLOR = "#F1AC4B"  # Sandy Brown
 
 PRIMARY_COLOR = "#4F2D7F"  # Minsk
-# Fondo general claro para el modo light
-DARK_BG_COLOR = "#FFFFFF"  # Light background
-# Fondo de la página con gradiente corporativo
-BG_GRADIENT = f"linear-gradient(135deg, {PRIMARY_COLOR} 0%, {ACCENT_COLOR} 100%)"
 # Color de fondo para secciones claras y tablas
 PRIMARY_BG = "#F8F1FA"
+# Fondo general claro para el modo light (se usa también para las gráficas)
+DARK_BG_COLOR = PRIMARY_BG
+# Fondo de la página con gradiente corporativo
+BG_GRADIENT = f"linear-gradient(135deg, {PRIMARY_COLOR} 0%, {ACCENT_COLOR} 100%)"
 # Color de las tablas sobre fondo claro
 TABLE_BG_COLOR = "#F8F9FA"
 WHITE = "#FFFFFF"

--- a/deploy_prophet.py
+++ b/deploy_prophet.py
@@ -5,6 +5,10 @@ import pandas as pd
 import matplotlib.pyplot as plt
 from preprocessing import forecast_target_prophet
 
+PRIMARY_BG = "#F8F1FA"  # Same background color used in the Streamlit app
+plt.rcParams["figure.facecolor"] = PRIMARY_BG
+plt.rcParams["axes.facecolor"] = PRIMARY_BG
+
 PROPHET_DIR = "models_prophet"
 TARGETS = ["T_VISITAS", "T_AO"]
 
@@ -47,7 +51,7 @@ def deploy_forecasts(df: pd.DataFrame, horizon_days: int = 365, changepoint_prio
             csv_name = f"{branch}_{target}_forecast.csv"
             forecast.to_csv(os.path.join(PROPHET_DIR, csv_name), index=False)
 
-            plt.figure()
+            plt.figure(facecolor=PRIMARY_BG)
             plt.plot(forecast["ds"], forecast["yhat"], label="forecast")
             plt.fill_between(
                 forecast["ds"],
@@ -59,6 +63,7 @@ def deploy_forecasts(df: pd.DataFrame, horizon_days: int = 365, changepoint_prio
             plt.xlabel("date")
             plt.ylabel(target)
             plt.legend()
+            plt.gca().set_facecolor(PRIMARY_BG)
             plt.grid(color="dimgray")
             plt.tight_layout()
             plot_name = f"{branch}_{target}_forecast.png"


### PR DESCRIPTION
## Summary
- use `PRIMARY_BG` as the universal chart background
- update Prophet deployment plots to use the same background color

## Testing
- `python -m py_compile app.py deploy_prophet.py preprocessing.py train_models.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_688d117203c48328853aae020f4ab7f3