### PR TITLE
Add weekday display to prediction table

### DIFF
--- a/app.py
+++ b/app.py
@@ -688,7 +688,7 @@ with tab_pred:
         """
     )
     gb.configure_column("Fecha registro", header_name="Fecha", rowGroup=True, hide=True)
-    gb.configure_column("Día", hide=True)
+    gb.configure_column("Día", header_name="Día de la semana")
     gb.configure_column("Hora", type=["numericColumn"])
     gb.configure_column("Visitas estimadas", type=["numericColumn"], aggFunc="sum",
                        valueFormatter="Math.round(params.value).toLocaleString('es-ES')")


### PR DESCRIPTION
## Summary
- modify Streamlit table setup so the day of week column is visible

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_688d1a15faa48328bd902757794c9a9a