### PR TITLE
Add white frames to visuals

### DIFF
--- a/app.py
+++ b/app.py
@@ -104,6 +104,12 @@ st.markdown(
     .stPlotlyChart div {{
       background: var(--bg-gradient) !important;
     }}
+    /* Pequeño marco blanco alrededor de gráficas y tablas */
+    .stPlotlyChart div, .stDataFrame, .stTable, .stDeckGlJson, .ag-theme-streamlit {{
+      border: 2px solid var(--white);
+      border-radius: 4px;
+      padding: 0.25rem;
+    }}
     /* Botones primarios */
     .stButton>button {{
       background-color: var(--primary);
@@ -165,7 +171,9 @@ st.markdown(
     /* Tablas incrustadas en el fondo */
     .stDataFrame, .stTable {{
       background-color: var(--table-bg) !important;
-      border: none;
+      border: 2px solid var(--white);
+      border-radius: 4px;
+      padding: 0.25rem;
     }}
     /* Ajustes extra para DataFrame en la pestaña Forecast */
     div[data-testid="stDataFrame"] > div {{


### PR DESCRIPTION
## Summary
- style visuals with a small white border for consistency

## Testing
- `pytest -q`
- `python -m py_compile app.py preprocessing.py utils.py train_models.py deploy_prophet.py`


------
https://chatgpt.com/codex/tasks/task_e_688d1bd8340083289b8d82911e3c4e9d