### PR TITLE
Add Excel download for dynamic table

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ correspondientes. Para publicar la app en línea puedes usar servicios como
 **Streamlit Community Cloud** o cualquier plataforma que ejecute aplicaciones
 Python (Heroku, GCP, AWS, etc.).
 
+- Sobre la tabla de predicciones podrás descargar los resultados en formato
+  Excel mediante el botón **"Descargar tabla en Excel"**.
+
 
 
 

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 import streamlit as st
 import pandas as pd
 import numpy as np
+from io import BytesIO
 from datetime import timedelta
 from train_models import generate_predictions
 import plotly.express as px
@@ -726,6 +727,16 @@ with tab_pred:
         allow_unsafe_jscode=True,
         use_container_width=True,
         fit_columns_on_grid_load=True,
+    )
+
+    # Botón para descargar la tabla dinámica en Excel
+    buffer = BytesIO()
+    df_grid.to_excel(buffer, index=False)
+    st.download_button(
+        "Descargar tabla en Excel",
+        data=buffer.getvalue(),
+        file_name="prediccion_diaria.xlsx",
+        mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     )
 
     # --- RECOMENDACIONES POR DíA Y TURNO ---


### PR DESCRIPTION
## Summary
- export the dynamic prediction table to Excel
- document new download button in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_688d1f544600832895e597e77e31b709