### PR TITLE
Fix day display in daily table

### DIFF
--- a/app.py
+++ b/app.py
@@ -689,7 +689,16 @@ with tab_pred:
         }
         """
     )
+    dia_renderer = JsCode(
+        """
+        function(params) {
+            // Show the day only on the group (date) rows
+            return params.node.group ? params.value : '';
+        }
+        """
+    )
     gb.configure_column("Fecha registro", header_name="Fecha", rowGroup=True, hide=True)
+    gb.configure_column("Día", aggFunc="first", cellRenderer=dia_renderer)
     gb.configure_column("Hora", type=["numericColumn"])
     gb.configure_column("Visitas estimadas", type=["numericColumn"], aggFunc="sum",
                        valueFormatter="Math.round(params.value).toLocaleString('es-ES')")


### PR DESCRIPTION
## Summary
- tweak AgGrid settings so that the day of week only shows on group rows

## Testing
- `python -m py_compile app.py`
- `python -m py_compile utils.py`


------
https://chatgpt.com/codex/tasks/task_e_688d3d39b20c83289d964a8711f771c2