### PR TITLE
Ensure staffing forecasts respect expected accepts

### DIFF
--- a/train_models.py
+++ b/train_models.py
@@ -222,6 +222,9 @@ def generate_predictions(
         dot_final = int(np.minimum(dot_opt, max_dot))
         result.loc[result["FECHA"] == fecha, "DOTACION_req"] = dot_final
 
+    # Asegurar que la dotación requerida por hora no supere las
+    # ofertas aceptadas esperadas para esa hora
+    result["DOTACION_req"] = np.minimum(result["DOTACION_req"], result["T_AO_pred"])
 
     return result
 


### PR DESCRIPTION
## Summary
- prevent required staffing from exceeding predicted accepted offers on an hourly basis

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890c10fef448328996710db58eed096