### PR TITLE
Limit staffing by required accepted offers

### DIFF
--- a/train_models.py
+++ b/train_models.py
@@ -223,8 +223,8 @@ def generate_predictions(
         result.loc[result["FECHA"] == fecha, "DOTACION_req"] = dot_final
 
     # Asegurar que la dotación requerida por hora no supere las
-    # ofertas aceptadas esperadas para esa hora
-    result["DOTACION_req"] = np.minimum(result["DOTACION_req"], result["T_AO_pred"])
+    # ofertas aceptadas requeridas para esa hora
+    result["DOTACION_req"] = np.minimum(result["DOTACION_req"], result["T_AO_VENTA_req"])
 
     return result
 


### PR DESCRIPTION
## Summary
- Ensure hourly staffing forecasts never exceed predicted required accepted offers

## Testing
- `python -m py_compile train_models.py`


------
https://chatgpt.com/codex/tasks/task_e_6890d065f88c83288b4c8ec58c39b21f