### PR TITLE
Floor avg dotacion requerida display in dynamic table

### DIFF
--- a/app.py
+++ b/app.py
@@ -708,8 +708,12 @@ with tab_pred:
                        valueFormatter="Math.round(params.value).toLocaleString('es-ES')")
     gb.configure_column("% Efectividad requerida", type=["numericColumn"], aggFunc="avg",
                        valueFormatter="params.value.toFixed(2)")
-    gb.configure_column("Dotación requerida", type=["numericColumn"], aggFunc="avg",
-                       valueFormatter="Math.round(params.value).toLocaleString('es-ES')")
+    gb.configure_column(
+        "Dotación requerida",
+        type=["numericColumn"],
+        aggFunc="avg",
+        valueFormatter="Math.floor(params.value).toLocaleString('es-ES')",
+    )
     gb.configure_column(
         "Dotación histórica",
         type=["numericColumn"],


### PR DESCRIPTION
## Summary
- use `Math.floor` in AgGrid value formatter to ensure average "Dotación requerida" values display as whole numbers

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890d19068f88328822b994eeaf4a457