### PR TITLE
Use max staffing per day instead of average

### DIFF
--- a/app.py
+++ b/app.py
@@ -711,7 +711,7 @@ with tab_pred:
     gb.configure_column(
         "Dotación requerida",
         type=["numericColumn"],
-        aggFunc="avg",
+        aggFunc="max",
         valueFormatter="Math.floor(params.value).toLocaleString('es-ES')",
     )
     gb.configure_column(


### PR DESCRIPTION
## Summary
- Display the maximum hourly staffing requirement in daily group rows instead of averaging.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6890d5e0433c832893012b0f9beaf34b