### PR TITLE
Use local logo image in header

### DIFF
--- a/app.py
+++ b/app.py
@@ -215,7 +215,7 @@ st.markdown(
 col1, col2, col3 = st.columns([1, 1, 1])
 with col2:
     st.image(
-        "https://upload.wikimedia.org/wikipedia/commons/2/27/Logo_Ripley_banco_2.png",
+        "logo.png",
         use_container_width=True
     )
 


### PR DESCRIPTION
## Summary
- Display logo.png from repository in the app's header instead of remote URL

## Testing
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68912fe908e88328b08d08124ab6ec2b